### PR TITLE
Added missing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN echo "deb http://http.debian.net/debian jessie-backports main" >/etc/apt/sou
     libffi-dev \
     build-essential \
     locales \
+    libblas-dev \
+    liblapack-dev \
     && apt-get install -yqq -t jessie-backports python-requests \
     && sed -i 's/^# en_US.UTF-8 UTF-8$/en_US.UTF-8 UTF-8/g' /etc/locale.gen \
     && locale-gen \
@@ -51,6 +53,7 @@ RUN echo "deb http://http.debian.net/debian jessie-backports main" >/etc/apt/sou
     && pip install airflow==$AIRFLOW_VERSION \
     && pip install airflow[celery]==$AIRFLOW_VERSION \
     && pip install airflow[mysql]==$AIRFLOW_VERSION \
+    && pip install airflow[hive]==$AIRFLOW_VERSION \
     && apt-get remove --purge -yqq build-essential python-pip python-dev libmysqlclient-dev libkrb5-dev libsasl2-dev libssl-dev libffi-dev \
     && apt-get clean \
     && rm -rf \


### PR DESCRIPTION
Hi Guys,

Really nice docker package for Airflow. Although I have some fixes which I would like to share. I've modified the Dockerfile a bit because of two reasons:

### Missing linear algebra Package

Adding the `libblas-dev` and `liblapack-dev` to the apt-get install command will fix this.

```
### Warning:  Using unoptimized lapack ###
### Warning:  Using unoptimized lapack ###
```

### Missing hive imports throws errors

Second, when running the container, the following error will appear due the missing Hive package.

```
webserver_1  | [2016-06-02 11:01:09,401] {models.py:250} ERROR - Failed to import: /usr/local/lib/python2.7/dist-packages/airflow/example_dags/example_twitter_dag.py
webserver_1  | Traceback (most recent call last):
webserver_1  |   File "/usr/local/lib/python2.7/dist-packages/airflow/models.py", line 247, in process_file
webserver_1  |     m = imp.load_source(mod_name, filepath)
webserver_1  |   File "/usr/local/lib/python2.7/dist-packages/airflow/example_dags/example_twitter_dag.py", line 26, in <module>
webserver_1  |     from airflow.operators import BashOperator, HiveOperator, PythonOperator
webserver_1  | ImportError: cannot import name HiveOperator
webserver_1  | [2016-06-02 11:01:09,439] {models.py:250} ERROR - Failed to import: /usr/local/lib/python2.7/dist-packages/airflow/example_dags/example_twitter_dag.py
webserver_1  | Traceback (most recent call last):
webserver_1  |   File "/usr/local/lib/python2.7/dist-packages/airflow/models.py", line 247, in process_file
webserver_1  |     m = imp.load_source(mod_name, filepath)
webserver_1  |   File "/usr/local/lib/python2.7/dist-packages/airflow/example_dags/example_twitter_dag.py", line 26, in <module>
webserver_1  |     from airflow.operators import BashOperator, HiveOperator, PythonOperator
webserver_1  | ImportError: cannot import name HiveOperator
```