### PR TITLE
Update docker-compose.yml for webserver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
         restart: always
         environment:
             - AIRFLOW_HOME=/usr/local/airflow
+        # volumes:
+        #     - /localpath/to/dags:/usr/local/airflow/dags
         ports:
             - "8080:8080"
         command: webserver


### PR DESCRIPTION
The webserver service also needs the DAGs folder mapped into its container, otherwise it will show that there is a DAG but with none of the other features available in the UI for that DAG.

The new additions here leave the volumes commented out, but do indicate to a user that it is required.