### PR TITLE
Use AIRFLOW__CORE__SQL_ALCHEMY_CONN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN set -ex \
         /usr/share/doc-base
 
 COPY script/entrypoint.sh /entrypoint.sh
+COPY script/test_conn /test_conn
 COPY config/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
 
 RUN chown -R airflow: ${AIRFLOW_HOME}

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -3,12 +3,9 @@
 AIRFLOW_HOME="/usr/local/airflow"
 CMD="airflow"
 TRY_LOOP="10"
-POSTGRES_HOST="postgres"
-POSTGRES_PORT="5432"
 RABBITMQ_HOST="rabbitmq"
 RABBITMQ_CREDS="airflow:airflow"
 : ${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print FERNET_KEY")}
-# FERNET_KEY=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print FERNET_KEY")
 
 # Load DAGs exemples (default: Yes)
 if [ "x$LOAD_EX" = "xn" ]; then
@@ -26,13 +23,13 @@ sed -i "s|\$FERNET_KEY|$FERNET_KEY|" "$AIRFLOW_HOME"/airflow.cfg
 # wait for DB
 if [ "$1" = "webserver" ] || [ "$1" = "worker" ] || [ "$1" = "scheduler" ] ; then
   i=0
-  while ! nc -z $POSTGRES_HOST $POSTGRES_PORT >/dev/null 2>&1 < /dev/null; do
+  while ! /test_conn; do
     i=$((i+1))
     if [ $i -ge $TRY_LOOP ]; then
-      echo "$(date) - ${POSTGRES_HOST}:${POSTGRES_PORT} still not reachable, giving up"
+      echo "$(date) - ${AIRFLOW__CORE__SQL_ALCHEMY_CONN} still not reachable, giving up"
       exit 1
     fi
-    echo "$(date) - waiting for ${POSTGRES_HOST}:${POSTGRES_PORT}... $i/$TRY_LOOP"
+    echo "$(date) - waiting for ${AIRFLOW__CORE__SQL_ALCHEMY_CONN}... $i/$TRY_LOOP"
     sleep 5
   done
   if [ "$1" = "webserver" ]; then

--- a/script/test_conn
+++ b/script/test_conn
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import psycopg2
+try:
+    from urllib.parse import urlparse # Python 3
+except ImportError: # Python 2
+    import urlparse
+
+schemes = ['postgres', 'psycopg2']
+url = urlparse.urlparse(os.getenv('AIRFLOW__CORE__SQL_ALCHEMY_CONN'))
+
+for scheme in schemes:
+    urlparse.uses_netloc.append(scheme)
+
+try:
+    psycopg2.connect(
+        database=url.path[1:],
+        user=url.username,
+        password=url.password,
+        host=url.hostname,
+        port=url.port)
+except:
+    sys.exit(1)
+
+sys.exit(0)


### PR DESCRIPTION
Use AIRFLOW__CORE__SQL_ALCHEMY_CONN environment variable instead of POSTGRES_HOST and
POSTGRES_PORT.
We use python, as it's provided with airflow, to accomplish this.