### PR TITLE
Install hadoop+hive on airflow docker to be able to connect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ ENV TERM linux
 # Airflow
 ARG AIRFLOW_VERSION=1.8.1
 ARG AIRFLOW_HOME=/usr/local/airflow
+ARG HADOOP_DIR=/usr/local/hadoop
+ARG HIVE_DIR=/usr/local/hive
 
 # Define en_US.
 ENV LANGUAGE en_US.UTF-8
@@ -22,6 +24,12 @@ ENV LC_ALL en_US.UTF-8
 ENV LC_CTYPE en_US.UTF-8
 ENV LC_MESSAGES en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
+
+# Resolve Hive and Hadoop stuff.
+ENV PATH $PATH:$HIVE_DIR/bin:$HADOOP_DIR/bin
+ENV HADOOP_HOME $HADOOP_DIR
+ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
+ENV HADOOP_OPTS "$HADOOP_OPTS -Djava.library.path=$HADOOP_HOME/lib/native"
 
 RUN set -ex \
     && buildDeps=' \
@@ -45,10 +53,15 @@ RUN set -ex \
         curl \
         netcat \
         locales \
+        openjdk-7-jdk \
     && sed -i 's/^# en_US.UTF-8 UTF-8$/en_US.UTF-8 UTF-8/g' /etc/locale.gen \
     && locale-gen \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
     && useradd -ms /bin/bash -d ${AIRFLOW_HOME} airflow \
+    && mkdir ${HADOOP_DIR} \
+    && chown -R airflow: ${HADOOP_DIR} \
+    && mkdir ${HIVE_DIR} \
+    && chown -R airflow: ${HIVE_DIR} \
     && python -m pip install -U pip \
     && pip install Cython \
     && pip install pytz \

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 AIRFLOW_HOME="/usr/local/airflow"
+HIVE_DIR="/usr/local/hive"
+HADOOP_DIR="/usr/local/hadoop"
 CMD="airflow"
 TRY_LOOP="20"
 
@@ -25,6 +27,24 @@ fi
 if [ -e "/requirements.txt" ]; then
     $(which pip) install --user -r /requirements.txt
 fi
+
+# Load DAGs exemples (default: Yes)
+if [ "$INSTALL_HIVE" = "y" ]; then
+    mkdir -p /tmp/hadoop
+    (cd /tmp/hadoop; curl -O https://archive.cloudera.com/cdh5/cdh/5/hadoop-2.6.0-cdh5.11.0.tar.gz)
+    (cd /tmp/hadoop; tar -zxf hadoop-2.6.0-cdh5.11.0.tar.gz)
+    (cd /tmp/hadoop; mv hadoop-2.6.0-cdh5.11.0/* $HADOOP_DIR)
+    mkdir -p /tmp/hive
+    (cd /tmp/hive; curl -O https://archive.cloudera.com/cdh5/cdh/5/hive-1.1.0-cdh5.11.0.tar.gz)
+    (cd /tmp/hive; tar -zxf hive-1.1.0-cdh5.11.0.tar.gz)
+    (cd /tmp/hive; mv hive-1.1.0-cdh5.11.0/* $HIVE_DIR)
+    rm -rf /tmp/hadoop
+    rm -rf /tmp/hive
+    cp /core-site.xml $HADOOP_DIR/etc/hadoop
+    cp /hdfs-site.xml $HADOOP_DIR/etc/hadoop
+    cp /mapred-site.xml $HADOOP_DIR/etc/hadoop
+fi
+
 
 # Update airflow config - Fernet key
 sed -i "s|\$FERNET_KEY|$FERNET_KEY|" "$AIRFLOW_HOME"/airflow.cfg


### PR DESCRIPTION
I'm developing a new example for my site and wanted to use the "hive" and "beeline" commands. I can only use that when hadoop+hive have a client installation in the airflow worker container. 

I'm not a docker practice expert, yet this PR demonstrates what I've been able to do to get the example working, attempting to go for minimal changes and impact.

Can we use this PR to evaluate together what the best method is to get these mundane packages installed and configured?  

Unless you're happy to accept them verbatim of course.

The relevant docker compose fragment would look like this: 

          - hive
      environment:
          - LOAD_EX=n
          - EXECUTOR=Local
          - INSTALL_HIVE=y
      volumes:
          - ./examples/hive-example/dags:/usr/local/airflow/dags
          - ./examples/hive-example/sql:/usr/local/airflow/sql
          - ./examples/hive-example/core-site.xml:/core-site.xml
          - ./examples/hive-example/hadoop-env.sh:/hadoop-env.sh
          - ./examples/hive-example/hdfs-site.xml:/hdfs-site.xml
          - ./examples/hive-example/mapred-site.xml:/mapred-site.xml