### PR TITLE
Fixing docker-compose file to handle correct linking for logging

### DIFF
--- a/docker-compose-CeleryExecutor.yml
+++ b/docker-compose-CeleryExecutor.yml
@@ -20,11 +20,11 @@ services:
             - LOAD_EX=y
             - FERNET_KEY=46BKJoQYlPPOexq0OhDZnIlNepKFf87WFwLbfzqDDho=
             - EXECUTOR=Celery
-            # - POSTGRES_USER=airflow
-            # - POSTGRES_PASSWORD=airflow
-            # - POSTGRES_DB=airflow
-        # volumes:
-            # - ~/docker-airflow/dags:/usr/local/airflow/dags
+            - POSTGRES_USER=airflow
+            - POSTGRES_PASSWORD=airflow
+            - POSTGRES_DB=airflow
+        #volumes:
+            #- ~/docker-airflow/dags:/usr/local/airflow/dags
         ports:
             - "8080:8080"
         command: webserver
@@ -45,28 +45,31 @@ services:
         restart: always
         depends_on:
             - webserver
-        # volumes:
-            # - ~/docker-airflow/dags:/usr/local/airflow/dags
+        #volumes:
+            #- ~/docker-airflow/dags:/usr/local/airflow/dags
         environment:
             - LOAD_EX=y
             - FERNET_KEY=46BKJoQYlPPOexq0OhDZnIlNepKFf87WFwLbfzqDDho=
             - EXECUTOR=Celery
-            # - POSTGRES_USER=airflow
-            # - POSTGRES_PASSWORD=airflow
-            # - POSTGRES_DB=airflow
+            - POSTGRES_USER=airflow
+            - POSTGRES_PASSWORD=airflow
+            - POSTGRES_DB=airflow
         command: scheduler
 
     worker:
         image: puckel/docker-airflow:1.8.1
         restart: always
         depends_on:
-            - scheduler
-        # volumes:
-            # - ~/docker-airflow/dags:/usr/local/airflow/dags
+            - webserver
+        #volumes:
+            #- ~/docker-airflow/dags:/usr/local/airflow/dags
         environment:
             - FERNET_KEY=46BKJoQYlPPOexq0OhDZnIlNepKFf87WFwLbfzqDDho=
             - EXECUTOR=Celery
-            # - POSTGRES_USER=airflow
-            # - POSTGRES_PASSWORD=airflow
-            # - POSTGRES_DB=airflow
+            - POSTGRES_USER=airflow
+            - POSTGRES_PASSWORD=airflow
+            - POSTGRES_DB=airflow
         command: worker
+        links:
+            - webserver
+


### PR DESCRIPTION
Since Postgres is part of the compose file I feel these should be uncommented. Also, there is an error that a lot of people are getting when bringing this up with the Celery executor.

This is what people would see in the logs for a run:

*** Log file isn't local.
***** Fetching here: http://:8793/log/tutl1/print_date1/2017-04-03T09:27:24**
*** Failed to fetch log file from worker.

*** Reading remote logs...
*** Unsupported remote log location.

The webserver is not able to fetch from the worker since they are not linked and thus there is no DNS available for the worker. This PR fixes this issue.