### PR TITLE
Remove airflow user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,8 @@ RUN set -ex \
     && sed -i 's/^# en_US.UTF-8 UTF-8$/en_US.UTF-8 UTF-8/g' /etc/locale.gen \
     && locale-gen \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
-    && useradd -ms /bin/bash -d ${AIRFLOW_HOME} airflow \
     && python -m pip install -U pip \
+    && pip install -U setuptools \
     && pip install Cython \
     && pip install pytz \
     && pip install pyOpenSSL \
@@ -70,10 +70,7 @@ RUN set -ex \
 COPY script/entrypoint.sh /entrypoint.sh
 COPY config/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
 
-RUN chown -R airflow: ${AIRFLOW_HOME}
-
 EXPOSE 8080 5555 8793
 
-USER airflow
 WORKDIR ${AIRFLOW_HOME}
 ENTRYPOINT ["/entrypoint.sh"]

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AIRFLOW_HOME="/usr/local/airflow"
+export AIRFLOW_HOME="/usr/local/airflow"
 CMD="airflow"
 TRY_LOOP="20"
 


### PR DESCRIPTION
I had some issues with connecting to the host docker socket using airflow's DockerOperator. The host docker socket was mounted correctly but "airflow" user had no permissions to use it. 

I tested that on macOS 10.12.5 with Docker:
```
Version 17.06.0-ce-mac17 (18432)
Channel: edge
4bb7a7dfa0
```

Removing "airflow" user fixed the problem as now root user has access to the socket. I wasn't able to figure out how to grant proper permissions to "airflow" user though.

Other changes:
- update setuptools,
- add `export` keyword to `AIRFLOW_HOME` env variable declaration as without it, it's not passed to descendant processes.

I know that this change is very opinioned but at the same time, I don't see any reason why airflow should be run with a dedicated user.