### PR TITLE
purge the depends of packages like build-essential

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN set -ex \
     && pip install pyasn1 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc]==$AIRFLOW_VERSION \
     && pip install celery[redis]==3.1.17 \
-    && apt-get remove --purge -yqq $buildDeps \
+    && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get clean \
     && rm -rf \
         /var/lib/apt/lists/* \


### PR DESCRIPTION
using `purge --auto-remove` instead of `remove`