### PR TITLE
Configure via env vars, not sed

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ For encrypted connection passwords (in Local or Celery Executor), you must have 
 
         python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print FERNET_KEY"
 
-Check [Airflow Documentation](https://pythonhosted.org/airflow/)
+## Configurating Airflow
+
+It is possible to set any configuration value for Airflow from environment variables, which are used over values from the airflow.cfg. The general rule is the environment variable should be named `AIRFLOW__<section>__<key>`, for example `AIRFLOW__CORE__SQL_ALCHEMY_CONN` sets the `sql_alchemy_conn` config option in the `[core]` section.
+
+Check out the [Airflow documentation](http://airflow.readthedocs.io/en/latest/configuration.html?highlight=__CORE__#setting-configuration-options) for more details
+
+You can also define connections via environment variables by prefixing them with `AIRFLOW_CONN_` - for example `AIRFLOW_CONN_POSTGRES_MASTER=postgres://user:password@localhost:5432/master` for a connection called "postgres_master". The value is parsed as a URI. This will work for hooks etc, but won't show up in the "Ad-hoc Query" section unless an (empty) connection is also created in the DB
 
 
 ## Install custom python package

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -4,17 +4,17 @@ AIRFLOW_HOME="/usr/local/airflow"
 CMD="airflow"
 TRY_LOOP="20"
 
-: ${REDIS_HOST:="redis"}
-: ${REDIS_PORT:="6379"}
-: ${REDIS_PASSWORD:=""}
+: "${REDIS_HOST:="redis"}"
+: "${REDIS_PORT:="6379"}"
+: "${REDIS_PASSWORD:=""}"
 
-: ${POSTGRES_HOST:="postgres"}
-: ${POSTGRES_PORT:="5432"}
-: ${POSTGRES_USER:="airflow"}
-: ${POSTGRES_PASSWORD:="airflow"}
-: ${POSTGRES_DB:="airflow"}
+: "${POSTGRES_HOST:="postgres"}"
+: "${POSTGRES_PORT:="5432"}"
+: "${POSTGRES_USER:="airflow"}"
+: "${POSTGRES_PASSWORD:="airflow"}"
+: "${POSTGRES_DB:="airflow"}"
 
-: ${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")}
+: "${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")}"
 
 # Load DAGs exemples (default: Yes)
 if [ "$LOAD_EX" = "n" ]; then
@@ -38,7 +38,7 @@ fi
 # Wait for Postresql
 if [ "$1" = "webserver" ] || [ "$1" = "worker" ] || [ "$1" = "scheduler" ] ; then
   i=0
-  while ! nc -z $POSTGRES_HOST $POSTGRES_PORT >/dev/null 2>&1 < /dev/null; do
+  while ! nc -z "$POSTGRES_HOST" "$POSTGRES_PORT" >/dev/null 2>&1 < /dev/null; do
     i=$((i+1))
     if [ "$1" = "webserver" ]; then
       echo "$(date) - waiting for ${POSTGRES_HOST}:${POSTGRES_PORT}... $i/$TRY_LOOP"
@@ -57,7 +57,7 @@ then
   # Wait for Redis
   if [ "$1" = "webserver" ] || [ "$1" = "worker" ] || [ "$1" = "scheduler" ] || [ "$1" = "flower" ] ; then
     j=0
-    while ! nc -z $REDIS_HOST $REDIS_PORT >/dev/null 2>&1 < /dev/null; do
+    while ! nc -z "$REDIS_HOST" "$REDIS_PORT" >/dev/null 2>&1 < /dev/null; do
       j=$((j+1))
       if [ $j -ge $TRY_LOOP ]; then
         echo "$(date) - $REDIS_HOST still not reachable, giving up"
@@ -73,10 +73,10 @@ then
   if [ "$1" = "webserver" ]; then
     echo "Initialize database..."
     $CMD initdb
-    exec $CMD webserver
+    exec "$CMD" webserver
   else
     sleep 10
-    exec $CMD "$@"
+    exec "$CMD" "$@"
   fi
 elif [ "$EXECUTOR" = "Local" ]
 then
@@ -85,17 +85,17 @@ then
   sed -i "s#broker_url = redis://redis:6379/1#broker_url = redis://$REDIS_PREFIX$REDIS_HOST:$REDIS_PORT/1#" "$AIRFLOW_HOME"/airflow.cfg
   echo "Initialize database..."
   $CMD initdb
-  exec $CMD webserver &
-  exec $CMD scheduler
+  exec "$CMD" webserver &
+  exec "$CMD" scheduler
 # By default we use SequentialExecutor
 else
   if [ "$1" = "version" ]; then
-    exec $CMD version
+    exec "$CMD" version
     exit
   fi
   sed -i "s/executor = CeleryExecutor/executor = SequentialExecutor/" "$AIRFLOW_HOME"/airflow.cfg
   sed -i "s#sql_alchemy_conn = postgresql+psycopg2://airflow:airflow@postgres/airflow#sql_alchemy_conn = sqlite:////usr/local/airflow/airflow.db#" "$AIRFLOW_HOME"/airflow.cfg
   echo "Initialize database..."
   $CMD initdb
-  exec $CMD webserver
+  exec "$CMD" webserver
 fi


### PR DESCRIPTION
This PR changes the entrypoint.sh script so that it doesn't need to change airflow.cfg to customize the settings.

The main reason we want this is that we have a repo which is our AIRFLOW_HOME, it contains a `dags/` folder, and custom plugins in  `plugins/`, some library functions/python modules and an `airflow.cfg`.

Because we have more than just the dags folder in our repo I'd prefer to not have to manually volume mount each thing individually and would prefer to just `docker run -v .:/usr/local/airflow`. Which works, except that our config is no longer default so some of the sed commands fail, and others end up changing the file which is tracked in git. All just a bit messy.

So since Airflow has built in feature to read config settings from environment variables we can just export some vars. No sed needed, no changes I need to revert every time in git (and an added bonus no changing to the base docker image at run time)