### PR TITLE
Adds rsync as a default package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN set -ex \
         python3-requests \
         apt-utils \
         curl \
+        rsync \
         netcat \
         locales \
     && sed -i 's/^# en_US.UTF-8 UTF-8$/en_US.UTF-8 UTF-8/g' /etc/locale.gen \


### PR DESCRIPTION
I think rsync is a package that is mostly used by data pipeline tasks.
I feel it should be a default package that's installed on the Dockerfile