### PR TITLE
Add a healthcheck to the webserver

### DIFF
--- a/docker-compose-CeleryExecutor.yml
+++ b/docker-compose-CeleryExecutor.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
     redis:
         image: 'redis:3.2.7'
@@ -28,6 +28,11 @@ services:
         ports:
             - "8080:8080"
         command: webserver
+        healthcheck:
+            test: ["CMD-SHELL", "[ -f /usr/local/airflow/airflow-webserver.pid ]"]
+            interval: 30s
+            timeout: 30s
+            retries: 3
 
     flower:
         image: puckel/docker-airflow:1.8.2

--- a/docker-compose-LocalExecutor.yml
+++ b/docker-compose-LocalExecutor.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
     postgres:
         image: postgres:9.6
@@ -20,3 +20,8 @@ services:
         ports:
             - "8080:8080"
         command: webserver
+        healthcheck:
+            test: ["CMD-SHELL", "[ -f /usr/local/airflow/airflow-webserver.pid ]"]
+            interval: 30s
+            timeout: 30s
+            retries: 3


### PR DESCRIPTION
This change is to reduce downtime when the issue described in https://issues.apache.org/jira/browse/AIRFLOW-1235 is encountered. (The master gunicorn process dies but the airflow CLI does not fail or restart, resulting in a dead webserver). Currently when this condition is met, the webserver has to be manually killed or restarted.

This change will poll for the airflow-webserver pid file and the webserver container will restart if it is not present (which is the case when the gunicorn master dies)

Related to #125