### PR TITLE
Add plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ Check out the [Airflow documentation](http://airflow.readthedocs.io/en/latest/co
 
 You can also define connections via environment variables by prefixing them with `AIRFLOW_CONN_` - for example `AIRFLOW_CONN_POSTGRES_MASTER=postgres://user:password@localhost:5432/master` for a connection called "postgres_master". The value is parsed as a URI. This will work for hooks etc, but won't show up in the "Ad-hoc Query" section unless an (empty) connection is also created in the DB
 
+## Custom Airflow plugins
+
+Airflow allows for custom user-created plugins which are typically found in `${AIRFLOW_HOME}/plugins` folder. Documentation on plugins can be found [here](https://airflow.apache.org/plugins.html)
+
+In order to incorporate plugins into your docker container
+- Create the plugins folders `plugins/` with your custom plugins.
+- Mount the folder as a volume by doing either of the following: 
+    - Include the folder as a volume in command-line `-v $(pwd)/plugins/:/usr/local/airflow/plugins`
+    - Use docker-compose-LocalExecutor.yml or docker-compose-CeleryExecutor.yml which contain support for adding the plugins folder as a volume
 
 ## Install custom python package
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ In order to incorporate plugins into your docker container
 - Create the plugins folders `plugins/` with your custom plugins.
 - Mount the folder as a volume by doing either of the following: 
     - Include the folder as a volume in command-line `-v $(pwd)/plugins/:/usr/local/airflow/plugins`
-    - Use docker-compose-LocalExecutor.yml or docker-compose-CeleryExecutor.yml which contain support for adding the plugins folder as a volume
+    - Use docker-compose-LocalExecutor.yml or docker-compose-CeleryExecutor.yml which contains support for adding the plugins folder as a volume
 
 ## Install custom python package
 

--- a/docker-compose-CeleryExecutor.yml
+++ b/docker-compose-CeleryExecutor.yml
@@ -31,6 +31,8 @@ services:
             # - REDIS_PASSWORD=redispass
         volumes:
             - ./dags:/usr/local/airflow/dags
+            # Uncomment to include custom plugins 
+            # - ./plugins:/usr/local/airflow/plugins
         ports:
             - "8080:8080"
         command: webserver
@@ -59,6 +61,8 @@ services:
             - webserver
         volumes:
             - ./dags:/usr/local/airflow/dags
+            # Uncomment to include custom plugins 
+            # - ./plugins:/usr/local/airflow/plugins
         environment:
             - LOAD_EX=n
             - FERNET_KEY=46BKJoQYlPPOexq0OhDZnIlNepKFf87WFwLbfzqDDho=
@@ -76,6 +80,8 @@ services:
             - scheduler
         volumes:
             - ./dags:/usr/local/airflow/dags
+            # Uncomment to include custom plugins 
+            # - ./plugins:/usr/local/airflow/plugins
         environment:
             - FERNET_KEY=46BKJoQYlPPOexq0OhDZnIlNepKFf87WFwLbfzqDDho=
             - EXECUTOR=Celery

--- a/docker-compose-LocalExecutor.yml
+++ b/docker-compose-LocalExecutor.yml
@@ -17,6 +17,8 @@ services:
             - EXECUTOR=Local
         volumes:
             - ./dags:/usr/local/airflow/dags
+            # Uncomment to include custom plugins 
+            # - ./plugins:/usr/local/airflow/dags
         ports:
             - "8080:8080"
         command: webserver

--- a/docker-compose-LocalExecutor.yml
+++ b/docker-compose-LocalExecutor.yml
@@ -18,7 +18,7 @@ services:
         volumes:
             - ./dags:/usr/local/airflow/dags
             # Uncomment to include custom plugins 
-            # - ./plugins:/usr/local/airflow/dags
+            # - ./plugins:/usr/local/airflow/plugins
         ports:
             - "8080:8080"
         command: webserver


### PR DESCRIPTION
To whom it may concern,

I have added documentation and code for the support of custom user created airflow plugins which typically belong in the `${AIRFLOW_HOME}/plugins` folder. As detailed in the documentation, users can either include the plugins on the command line as a volume or use the yml files which have plugin support. Please feel free to follow up on this pull request and provide comments.