### PR TITLE
Fix celery result_backend config variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 ENV LC_CTYPE en_US.UTF-8
 ENV LC_MESSAGES en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
 
 RUN set -ex \
     && buildDeps=' \
@@ -50,7 +49,7 @@ RUN set -ex \
     && locale-gen \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
     && useradd -ms /bin/bash -d ${AIRFLOW_HOME} airflow \
-    && python -m pip install -U pip setuptools wheel \
+    && pip install -U pip setuptools wheel \
     && pip install Cython \
     && pip install pytz \
     && pip install pyOpenSSL \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN set -ex \
         git \
     ' \
     && apt-get update -yqq \
+    && apt-get upgrade -yqq \
     && apt-get install -yqq --no-install-recommends \
         $buildDeps \
         python3-pip \

--- a/config/airflow.cfg
+++ b/config/airflow.cfg
@@ -253,7 +253,7 @@ worker_log_server_port = 8793
 broker_url = redis://redis:6379/1
 
 # Another key Celery setting
-celery_result_backend = db+postgresql://airflow:airflow@postgres/airflow
+result_backend = db+postgresql://airflow:airflow@postgres/airflow
 
 # Celery Flower is a sweet UI for Celery. Airflow has a shortcut to start
 # it `airflow flower`. This defines the IP that Celery Flower runs on

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -57,7 +57,7 @@ wait_for_port() {
 }
 
 wait_for_redis() {
-  # Wait for Redis iff we are using it
+  # Wait for Redis if we are using it
   if [ "$AIRFLOW__CORE__EXECUTOR" = "CeleryExecutor" ]
   then
     wait_for_port "Redis" "$REDIS_HOST" "$REDIS_PORT"


### PR DESCRIPTION
The variable was prepended with "celery_", which is wrong. It is already under
the "celery" group.