### PR TITLE
Add packages which allow Airflow mysql hook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN set -ex \
         python3-pip \
         python3-requests \
         libmysqlclient-dev \
+        mysql \
         apt-utils \
         curl \
         netcat \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN set -ex \
         python3-requests \
         mysql-client \
         mysql-server \
+        libmysqlclient-dev \
         apt-utils \
         curl \
         rsync \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ RUN set -ex \
         $buildDeps \
         python3-pip \
         python3-requests \
-        libmysqlclient-dev \
-        mysql \
+        mysql-client \
+        mysql-server \
         apt-utils \
         curl \
         rsync \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN set -ex \
         $buildDeps \
         python3-pip \
         python3-requests \
+        libmysqlclient-dev \
         apt-utils \
         curl \
         netcat \
@@ -55,7 +56,7 @@ RUN set -ex \
     && pip install pyOpenSSL \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
-    && pip install apache-airflow[crypto,celery,postgres,hive,jdbc]==$AIRFLOW_VERSION \
+    && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql]==$AIRFLOW_VERSION \
     && pip install celery[redis]==3.1.17 \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get clean \


### PR DESCRIPTION
Currently, the Airflow mysql_hook import fails because the related MySqlDb packages are not installed, which is dependent on mysql_config being present from the mysql installation available on the machine.
This pull request adds necessary packages to allow airflow hooks for mysql to function.