### PR TITLE
Update broken Airflow docs link for Extra packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pull the image from the Docker repository.
 
 ## Build
 
-For example, if you need to install [Extra Packages](https://pythonhosted.org/airflow/installation.html#extra-package), edit the Dockerfile and then build it.
+For example, if you need to install [Extra Packages](https://airflow.incubator.apache.org/airflow/installation.html#extra-package), edit the Dockerfile and then build it.
 
         docker build --rm -t puckel/docker-airflow .
 


### PR DESCRIPTION
- Updated the broken link for Airflow Docs from https://pythonhosted.org/airflow to https://airflow.incubator.apache.org