### PR TITLE
Fix the Airflow doc Extra package link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pull the image from the Docker repository.
 
 ## Build
 
-For example, if you need to install [Extra Packages](https://airflow.incubator.apache.org/airflow/installation.html#extra-package), edit the Dockerfile and then build it.
+For example, if you need to install [Extra Packages](https://airflow.incubator.apache.org/installation.html#extra-package), edit the Dockerfile and then build it.
 
         docker build --rm -t puckel/docker-airflow .
 


### PR DESCRIPTION
- In the last pull (https://github.com/puckel/docker-airflow/pull/171), I forgot to remove "/airflow/" from the path which is now fixed and tested.