### PR TITLE
Remove unnecessary packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN set -ex \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql]==$AIRFLOW_VERSION \
     && pip install celery[redis]==4.0.2 \
     && apt-get purge --auto-remove -yqq $buildDeps \
+    && apt-get autoremove -yqq --purge \
     && apt-get clean \
     && rm -rf \
         /var/lib/apt/lists/* \


### PR DESCRIPTION
* Before:

```
$ docker run -it --rm --user root puckel/docker-airflow:1.9.0-2 bash
root@22e9e32775d4:/usr/local/airflow#
root@22e9e32775d4:/usr/local/airflow# apt-get update
Hit http://security.debian.org jessie/updates InRelease
Ign http://deb.debian.org jessie InRelease
Get:1 http://security.debian.org jessie/updates/main amd64 Packages [644 kB]
Get:2 http://deb.debian.org jessie-updates InRelease [145 kB]
Get:3 http://deb.debian.org jessie Release.gpg [2,434 B]
Get:4 http://deb.debian.org jessie-updates/main amd64 Packages [23.1 kB]
Get:5 http://deb.debian.org jessie Release [148 kB]
Get:6 http://deb.debian.org jessie/main amd64 Packages [9,064 kB]
Fetched 9,882 kB in 19s (499 kB/s)
Reading package lists... Done
root@22e9e32775d4:/usr/local/airflow# apt-get upgrade
Reading package lists... Done
Building dependency tree
Reading state information... Done
Calculating upgrade... The following packages were automatically installed and are no longer required:
  binutils bzip2 cpp cpp-4.9 dpkg-dev g++ g++-4.9 gcc gcc-4.9 libasan1 libatomic1 libc-dev-bin libc6-dev libcilkrts5 libcloog-isl4 libdpkg-perl libexpat1-dev libgcc-4.9-dev libgomp1 libisl10 libitm1 liblsan0
  libmpc3 libmpfr4 libpython3-dev libpython3.4 libpython3.4-dev libquadmath0 libstdc++-4.9-dev libtimedate-perl libtsan0 libubsan0 linux-libc-dev make patch perl perl-modules python3.4-dev xz-utils
Use 'apt-get autoremove' to remove them.
Done
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
root@22e9e32775d4:/usr/local/airflow#
```