### PR TITLE
Update celery to 4.1.1 hotfix for kombu 4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN set -ex \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql]==$AIRFLOW_VERSION \
-    && pip install celery[redis]==4.0.2 \
+    && pip install celery[redis]==4.1.1 \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \


### PR DESCRIPTION
Worker gives KeyError async on fresh docker build due to Kombu 4.2. Result is a continually failing/rebooting worker.

Tracked it down to this issue.
https://github.com/celery/celery/issues/4753

Should upgrade to celery 4.2 when stable