### PR TITLE
add default arg for docker run to be webserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,3 +82,4 @@ EXPOSE 8080 5555 8793
 USER airflow
 WORKDIR ${AIRFLOW_HOME}
 ENTRYPOINT ["/entrypoint.sh"]
+CMD ["webserver"] # set default arg for entrypoint


### PR DESCRIPTION
allows a user to run `docker run -p 8080:8080 docker-airflow` standalone without having to specify args. any arg supplied will override this default.