### PR TITLE
Fix instructions for running with SequentialExecutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Don't forget to update the airflow images in the docker-compose files to puckel/
 
 By default, docker-airflow runs Airflow with **SequentialExecutor** :
 
-    docker run -d -p 8080:8080 puckel/docker-airflow
+    docker run -d -p 8080:8080 puckel/docker-airflow webserver
 
 If you want to run another executor, use the other docker-compose.yml files provided in this repository.
 


### PR DESCRIPTION
Without the `webserver` argument the container starts up and immediately exits.

This is a quick-fix, better might be to set the default CMD in the Dockerfile