### PR TITLE
Allow to customize parameters for webserver launch

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -74,7 +74,7 @@ case "$1" in
       # With the "Local" executor it should all run in one container.
       airflow scheduler &
     fi
-    exec airflow webserver
+    exec airflow "$@"
     ;;
   worker|scheduler)
     # To give the webserver time to run initdb.


### PR DESCRIPTION
Sometimes we need to pass custom parameters when
starting webserver [1], e.g.
   --workerclass
   --workers

[1]. https://airflow.apache.org/cli.html?#webserver