### PR TITLE
Fix python module requirement that breaks SSHOperator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN set -ex \
     && pip install pyasn1 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql]==$AIRFLOW_VERSION \
     && pip install 'celery[redis]>=4.1.1,<4.2.0' \
+    && pip install paramiko \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \


### PR DESCRIPTION
This pip installs the `paramiko` , which is strictly required for the `SSHOperator` to work.
As this is an important core functionality that should be added anyway, it makes sense to install it at container build time rather than each time via `requirements.txt` in the entrypoint script.

Fixes https://github.com/puckel/docker-airflow/issues/145