### PR TITLE
Add chmod to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ COPY script/entrypoint.sh /entrypoint.sh
 COPY config/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
 
 RUN chown -R airflow: ${AIRFLOW_HOME}
+RUN chmod 755 /entrypoint.sh
 
 EXPOSE 8080 5555 8793
 


### PR DESCRIPTION
I was referencing this dockerfile and didn't realize at first that the `entrypoint.sh` file needed to be declared executable.  

Doing this makes it verbose that it needs to be AND takes care of it in the dockerfile. 

I consulted this documentation when defining which chmod value to use: https://kb.iu.edu/d/abdb