### PR TITLE
FERNET_KEY not properly being generated

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -13,7 +13,7 @@ TRY_LOOP="20"
 : "${POSTGRES_DB:="airflow"}"
 
 # Defaults and back-compat
-: "${AIRFLOW__CORE__FERNET_KEY:=${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")}}"
+: "${AIRFLOW__CORE__FERNET_KEY:=${FERNET_KEY:-$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")}}"
 : "${AIRFLOW__CORE__EXECUTOR:=${EXECUTOR:-Sequential}Executor}"
 
 export \


### PR DESCRIPTION
Given a fresh docker-compose using LocalExecutor, fernet_key value is $FERNET_KEY, and not actual key value. Executing this change on my local container's entrypoint.sh, and then re executing the file results in the fernet_key value being the actual key.
Here is a terminal snippet of the before and after python terminal commands executed that reveal the difference:
`Python 3.6.6 (default, Oct 16 2018, 07:20:07) `
`[GCC 6.3.0 20170516] on linux`
`Type "help", "copyright", "credits" or "license" for more information.`
`>>> from airflow import configuration`
`>>> configuration.get('core','fernet_key')`
`'$FERNET_KEY'`

`Python 3.6.6 (default, Oct 16 2018, 07:20:07) `
`[GCC 6.3.0 20170516] on linux`
`Type "help", "copyright", "credits" or "license" for more information.`
`>>> from airflow import configuration`
`>>> configuration.get('core','fernet_key')`
`'z-NEp1WcNs_gLnwBHfB9CvwQmsRqJ9hS-5loNffNNIY='`