### PR TITLE
Drop build packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,6 @@ RUN set -ex \
         libsasl2-dev \
         libssl-dev \
         libffi-dev \
-        libblas-dev \
-        liblapack-dev \
         libpq-dev \
         git \
     ' \


### PR DESCRIPTION
Now that most scientific packages ship with wheels, we shouldn't need to install blas or lapack.