### PR TITLE
Add 10 second sleep period before Flower container starts

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -82,6 +82,9 @@ case "$1" in
     exec airflow "$@"
     ;;
   flower)
+    # Flower relies on having the `log` table, and thus also needs to sleep for
+    # to allow the database to be initialized.
+    sleep 10
     exec airflow "$@"
     ;;
   version)


### PR DESCRIPTION
This PR addresses 'Error 1' (the first part) of #270, which is that the `flower` component  relies on the existence of the `log` table that is created by the `airflow initdb` command (see migration code [here](https://github.com/apache/incubator-airflow/blob/master/airflow/migrations/versions/e3a246e0dc1_current_schema.py#L121)), which is run in the webserver container. When that process has not completed running, the flower command will throw an error on start up. 

Although this is perhaps harmless, since the container has a `restart: always` policy, and by the time it restarts, the table will exist, I supposed it would be nice if the error was not thrown at all.

I also wonder if you have thoughts about keeping the `flower` branch of the case statement separate now it is sleeping as well, or whether it should be collapsed into the same `worker|scheduler` branch. I leaned on the side of keeping them separate to preserve structure for folks who have seen the distinct branches already and might wonder "where did flower go?", or for folks who have done other things to separate the start up processes between these two groups.
