### PR TITLE
airflow logs written in a volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,8 @@ RUN set -ex \
 
 COPY script/entrypoint.sh /entrypoint.sh
 COPY config/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
-
-RUN chown -R airflow: ${AIRFLOW_HOME}
+RUN mkdir ${AIRFLOW_HOME}/logs && chown -R airflow: ${AIRFLOW_HOME}
+VOLUME /usr/local/airflow/logs/
 
 EXPOSE 8080 5555 8793
 


### PR DESCRIPTION
making log directory to a volume prevents diff creation by docker.

also helps with #224 