### PR TITLE
Move init DB into scheduler

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -69,15 +69,21 @@ fi
 
 case "$1" in
   webserver)
-    airflow initdb
     if [ "$AIRFLOW__CORE__EXECUTOR" = "LocalExecutor" ]; then
       # With the "Local" executor it should all run in one container.
+      airflow initdb
       airflow scheduler &
+    else
+      # To give the scheduler time to run initdb.
+      sleep 10
     fi
     exec airflow webserver
     ;;
-  worker|scheduler)
-    # To give the webserver time to run initdb.
+  scheduler)
+    airflow initdb
+    exec airflow "$@"
+    ;;
+  worker)
     sleep 10
     exec airflow "$@"
     ;;


### PR DESCRIPTION
Scheduler must be unique, so it’s a reasonable place to run the DB init, rather than potential multiple instances running with the webserver entry.
Addresses #163