### PR TITLE
Allow control of DB actions on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ NB : If you want to have DAGs example loaded (default=False), you've to set the 
 
     docker run -d -p 8080:8080 -e LOAD_EX=y puckel/docker-airflow
 
+If you want to control database actions on boot, you've to set the following environment variable with one of `init`,`update`,`none`:
+
+`DB_RUN_ACTION=init`
+
+    docker run -d -p 8080:8080 -e DB_RUN_ACTION=update puckel/docker-airflow
+
+This will run one of `airflow initdb`, `airflow updatedb`, or perform no database action when the webserver starts.
+
+
 If you want to use Ad hoc query, make sure you've configured connections:
 Go to Admin -> Connections and Edit "postgres_default" set this values (equivalent to values in airflow.cfg/docker-compose*.yml) :
 - Host : postgres

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -69,15 +69,21 @@ fi
 
 case "$1" in
   webserver)
-    airflow initdb
     if [ "$AIRFLOW__CORE__EXECUTOR" = "LocalExecutor" ]; then
       # With the "Local" executor it should all run in one container.
+      airflow initdb
       airflow scheduler &
+    else
+      # To give the scheduler time to run initdb.
+      sleep 10
     fi
     exec airflow webserver
     ;;
-  worker|scheduler)
-    # To give the webserver time to run initdb.
+  scheduler)
+    airflow initdb
+    exec airflow "$@"
+    ;;
+  worker)
     sleep 10
     exec airflow "$@"
     ;;


### PR DESCRIPTION
There is not always a wish to specifically run `airflow initdb` whenever the webserver starts. A user may wish to only run `airflow updatedb`, to handle their DB actions in another manner.

This PR allows the user to set an enviroment variable `DB_RUN_ACTION` which takes one of three values `init`,`update`,`none`, where the default is `init` to preserve current functionality.