### PR TITLE
Bump airflow version (#2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 jobs:
-  build:
+  build_and_test:
     docker:
       - image: docker:18.06.1-ce-git
     working_directory: ~/CircleCI/docker-airflow
@@ -9,22 +9,16 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: |
-          docker build -t puckel/docker-airflow .
-
-  test:
-    docker:
-      - image: docker:18.06.1-ce-git
-    steps:
-      - setup_remote_docker
-      - run: |
-          docker run puckel/docker-airflow version |grep '1.10.1'
-
+      - run: 
+          name: Build docker image
+          command: |
+            docker build -t puckel/docker-airflow .
+      - run: 
+          name: Test docker image
+          command: |
+            docker run puckel/docker-airflow version |grep '1.10.2'
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
-      - test:
-          requires:
-            - build
+      - build_and_test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# VERSION 1.10.1
+# VERSION 1.10.2
 # AUTHOR: Matthieu "Puckel_" Roisil
 # DESCRIPTION: Basic Airflow container
 # BUILD: docker build --rm -t puckel/docker-airflow .
@@ -12,7 +12,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
 # Airflow
-ARG AIRFLOW_VERSION=1.10.1
+ARG AIRFLOW_VERSION=1.10.2
 ARG AIRFLOW_HOME=/usr/local/airflow
 ARG AIRFLOW_DEPS=""
 ARG PYTHON_DEPS=""

--- a/docker-compose-CeleryExecutor.yml
+++ b/docker-compose-CeleryExecutor.yml
@@ -16,7 +16,7 @@ services:
         #     - ./pgdata:/var/lib/postgresql/data/pgdata
 
     webserver:
-        image: puckel/docker-airflow:1.10.1
+        image: puckel/docker-airflow:1.10.2
         restart: always
         depends_on:
             - postgres
@@ -43,7 +43,7 @@ services:
             retries: 3
 
     flower:
-        image: puckel/docker-airflow:1.10.1
+        image: puckel/docker-airflow:1.10.2
         restart: always
         depends_on:
             - redis
@@ -55,7 +55,7 @@ services:
         command: flower
 
     scheduler:
-        image: puckel/docker-airflow:1.10.1
+        image: puckel/docker-airflow:1.10.2
         restart: always
         depends_on:
             - webserver
@@ -74,7 +74,7 @@ services:
         command: scheduler
 
     worker:
-        image: puckel/docker-airflow:1.10.1
+        image: puckel/docker-airflow:1.10.2
         restart: always
         depends_on:
             - scheduler

--- a/docker-compose-LocalExecutor.yml
+++ b/docker-compose-LocalExecutor.yml
@@ -8,7 +8,7 @@ services:
             - POSTGRES_DB=airflow
 
     webserver:
-        image: puckel/docker-airflow:1.10.1
+        image: puckel/docker-airflow:1.10.2
         restart: always
         depends_on:
             - postgres


### PR DESCRIPTION
I made this PR to :

- Bump airflow version to 1.10.2. Changelog is available on https://github.com/apache/airflow/blob/1.10.2/CHANGELOG.txt.

- Fix CI :
In fact, the actual version, build a docker Image locally (build step). Then we test the image from docker hub (test step) which is different from the local one.
By using the same step, we can build the image locally and test it. 



