### PR TITLE
Fix Sequential Executor without start scheduler

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -70,8 +70,8 @@ fi
 case "$1" in
   webserver)
     airflow initdb
-    if [ "$AIRFLOW__CORE__EXECUTOR" = "LocalExecutor" ]; then
-      # With the "Local" executor it should all run in one container.
+    if [ "$AIRFLOW__CORE__EXECUTOR" = "SequentialExecutor" ] || [ "$AIRFLOW__CORE__EXECUTOR" = "LocalExecutor" ]; then
+      # With the "Local" or "Sequential" executor it should all run in one container.
       airflow scheduler &
     fi
     exec airflow webserver


### PR DESCRIPTION
Fix https://github.com/puckel/docker-airflow/issues/254
In readme run `docker run -d -p 8080:8080 puckel/docker-airflow webserver`
will not start scheduler
this PR fix it

detail:
* while running `docker run -d -p 8080:8080 puckel/docker-airflow webserver`, ENV `EXECUTOR` is None and `AIRFLOW__CORE__EXECUTOR = SequentialExecutor` due to  https://github.com/puckel/docker-airflow/blob/024cf2d08d2de1edf63f780c4d60c5d8fc70b265/script/entrypoint.sh#L17
* run `puckel/docker-airflow webserver` will run this line
https://github.com/puckel/docker-airflow/blob/024cf2d08d2de1edf63f780c4d60c5d8fc70b265/script/entrypoint.sh#L71
but `AIRFLOW__CORE__EXECUTOR = SequentialExecutor` so in `AIRFLOW__CORE__EXECUTOR = SequentialExecutor` dissatisfaction the condition, so https://github.com/puckel/docker-airflow/blob/024cf2d08d2de1edf63f780c4d60c5d8fc70b265/script/entrypoint.sh#L75 will not run.

add condition `[ "$AIRFLOW__CORE__EXECUTOR" = "SequentialExecutor" ]` in `if` syntax will fix it