### PR TITLE
Re: Bump version v1.10.3 - Based on PR #355 with fixes.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run: 
           name: Test docker image
           command: |
-            docker run puckel/docker-airflow version |grep '1.10.2'
+            docker run puckel/docker-airflow version |grep '1.10.3'
 workflows:
   version: 2
   build_and_test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# VERSION 1.10.2
+# VERSION 1.10.3
 # AUTHOR: Matthieu "Puckel_" Roisil
 # DESCRIPTION: Basic Airflow container
 # BUILD: docker build --rm -t puckel/docker-airflow .
@@ -12,11 +12,10 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
 # Airflow
-ARG AIRFLOW_VERSION=1.10.2
+ARG AIRFLOW_VERSION=1.10.3
 ARG AIRFLOW_HOME=/usr/local/airflow
 ARG AIRFLOW_DEPS=""
 ARG PYTHON_DEPS=""
-ENV AIRFLOW_GPL_UNIDECODE yes
 
 # Define en_US.
 ENV LANGUAGE en_US.UTF-8
@@ -57,7 +56,8 @@ RUN set -ex \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
-    && pip install 'redis>=2.10.5,<3' \
+    # && pip install 'redis>=2.10.5,<3' \
+    && pip install 'redis==3.2' \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get autoremove -yqq --purge \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,6 @@ RUN set -ex \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
-    # && pip install 'redis>=2.10.5,<3' \
     && pip install 'redis==3.2' \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \
     && apt-get purge --auto-remove -yqq $buildDeps \

--- a/config/airflow.cfg
+++ b/config/airflow.cfg
@@ -1,7 +1,4 @@
 [core]
-# The home folder for airflow, default is ~/airflow
-airflow_home = /usr/local/airflow
-
 # The folder where your airflow pipelines live, most likely a
 # subfolder in a code repository
 # This path must be absolute
@@ -117,7 +114,7 @@ donot_pickle = False
 dagbag_import_timeout = 30
 
 # The class to use for running task instances in a subprocess
-task_runner = BashTaskRunner
+task_runner = StandardTaskRunner
 
 # If set, tasks without a `run_as_user` argument will be run with this user
 # Can be used to de-elevate a sudo user running Airflow when executing tasks
@@ -152,6 +149,9 @@ dag_run_conf_overrides_params = False
 
 # Worker initialisation check to validate Metadata Database connection
 worker_precheck = False
+
+# When discovering DAGs, ignore any files that don't contain the strings `DAG` and `airflow`.
+dag_discovery_safe_mode = False
 
 [cli]
 # In what way should the cli access the API. The LocalClient will use the
@@ -247,7 +247,7 @@ error_logfile = -
 expose_config = True
 
 # Set to true to turn on authentication:
-# https://airflow.incubator.apache.org/security.html#web-authentication
+# https://airflow.apache.org/security.html#web-authentication
 authenticate = False
 
 # Filter the list of dags by owner name (requires authentication to be enabled)
@@ -292,6 +292,15 @@ navbar_color = #007A87
 # Default dagrun to show in UI
 default_dag_run_display_number = 25
 
+# Enable werkzeug `ProxyFix` middleware
+enable_proxy_fix = False
+
+# Set secure flag on session cookie
+cookie_secure = False
+
+# Set samesite policy on session cookie
+cookie_samesite =
+
 [email]
 email_backend = airflow.utils.email.send_email_smtp
 
@@ -321,6 +330,14 @@ celery_app_name = airflow.executors.celery_executor
 # your worker box and the nature of your tasks
 worker_concurrency = 16
 
+# The maximum and minimum concurrency that will be used when starting workers with the
+# "airflow worker" command (always keep minimum processes, but grow to maximum if necessary).
+# Note the value should be "max_concurrency,min_concurrency"
+# Pick these numbers based on resources on worker box and the nature of the task.
+# If autoscale option is available, worker_concurrency will be ignored.
+# http://docs.celeryproject.org/en/latest/reference/celery.bin.worker.html#cmdoption-celery-worker-autoscale
+# worker_autoscale = 16,12
+
 # When you start an airflow worker, airflow starts a tiny web server
 # subprocess to serve the workers local log files to the airflow main
 # web server, who then builds pages and sends them to users. This defines
@@ -331,9 +348,15 @@ worker_log_server_port = 8793
 # The Celery broker URL. Celery supports RabbitMQ, Redis and experimentally
 # a sqlalchemy database. Refer to the Celery documentation for more
 # information.
+# http://docs.celeryproject.org/en/latest/userguide/configuration.html#broker-settings
 broker_url = redis://redis:6379/1
 
-# Another key Celery setting
+# The Celery result_backend. When a job finishes, it needs to update the
+# metadata of the job. Therefore it will post a message on a message bus,
+# or insert it into a database (depending of the backend)
+# This status is used by the scheduler to update the state of the task
+# The use of a database is highly recommended
+# http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-result-backend-settings
 result_backend = db+postgresql://airflow:airflow@postgres/airflow
 
 # Celery Flower is a sweet UI for Celery. Airflow has a shortcut to start
@@ -347,8 +370,17 @@ flower_url_prefix =
 # This defines the port that Celery Flower runs on
 flower_port = 5555
 
+# Securing Flower with Basic Authentication
+# Accepts user:password pairs separated by a comma
+# Example: flower_basic_auth = user1:password1,user2:password2
+flower_basic_auth =
+
 # Default queue that tasks get assigned to and that worker listen on.
 default_queue = default
+
+# How many processes CeleryExecutor uses to sync task state.
+# 0 means to use max(1, number of cores - 1) processes.
+sync_parallelism = 0
 
 # Import path for celery configuration options
 celery_config_options = airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG
@@ -401,7 +433,7 @@ scheduler_heartbeat_sec = 5
 # -1 indicates to run continuously (see also num_runs)
 run_duration = -1
 
-# after how much time a new DAGs should be picked up from the filesystem
+# after how much time (seconds) a new DAGs should be picked up from the filesystem
 min_file_process_interval = 0
 
 # How often (in seconds) to scan the DAGs directory for new files. Default to 5 minutes.
@@ -409,6 +441,12 @@ dag_dir_list_interval = 300
 
 # How often should stats be printed to the logs
 print_stats_interval = 30
+
+# If the last scheduler heartbeat happened more than scheduler_health_check_threshold ago (in seconds),
+# scheduler is considered unhealthy.
+# This is used by the health check in the "/health" endpoint
+# This is used by the health check in the "/health" endpoint
+scheduler_health_check_threshold = 30
 
 child_process_log_directory = /usr/local/airflow/logs/scheduler
 
@@ -426,8 +464,15 @@ scheduler_zombie_task_threshold = 300
 catchup_by_default = True
 
 # This changes the batch size of queries in the scheduling main loop.
-# This depends on query length limits and how long you are willing to hold locks.
-# 0 for no limit
+# If this is too high, SQL query performance may be impacted by one
+# or more of the following:
+#  - reversion to full table scan
+#  - complexity of query predicate
+#  - excessive locking
+#
+# Additionally, you may hit the maximum allowable query length for your db.
+#
+# Set this to 0 for no limit (not advised)
 max_tis_per_query = 512
 
 # Statsd (https://github.com/etsy/statsd) integration settings
@@ -459,6 +504,10 @@ bind_password = insecure
 basedn = dc=example,dc=com
 cacert = /etc/ca/ldap_ca.crt
 search_scope = LEVEL
+
+# This setting allows the use of LDAP servers that either return a 
+# broken schema, or do not return a schema. 
+ignore_malformed_schema = False
 
 [mesos]
 # Mesos master address which MesosExecutor will connect to.
@@ -528,10 +577,12 @@ elasticsearch_end_of_log_mark = end_of_log
 worker_container_repository =
 worker_container_tag =
 worker_container_image_pull_policy = IfNotPresent
-worker_dags_folder =
 
 # If True (default), worker pods will be deleted upon termination
 delete_worker_pods = True
+
+# Number of Kubernetes Worker Pod creation calls per scheduler loop
+worker_pods_creation_batch_size = 1
 
 # The Kubernetes namespace where airflow workers should be created. Defaults to `default`
 namespace = default
@@ -539,10 +590,14 @@ namespace = default
 # The name of the Kubernetes ConfigMap Containing the Airflow Configuration (this file)
 airflow_configmap =
 
+# For docker image already contains DAGs, this is set to `True`, and the worker will search for dags in dags_folder,
+# otherwise use git sync or dags volume claim to mount DAGs
+dags_in_image = False
+
 # For either git sync or volume mounted DAGs, the worker will look in this subpath for DAGs
 dags_volume_subpath =
 
-# For DAGs mounted via a volume claim (mutually exclusive with volume claim)
+# For DAGs mounted via a volume claim (mutually exclusive with git-sync and host path)
 dags_volume_claim =
 
 # For volume mounted logs, the worker will look in this subpath for logs
@@ -551,16 +606,69 @@ logs_volume_subpath =
 # A shared volume claim for the logs
 logs_volume_claim =
 
+
+# For DAGs mounted via a hostPath volume (mutually exclusive with volume claim and git-sync)
+# Useful in local environment, discouraged in production
+dags_volume_host =
+
+# A hostPath volume for the logs
+# Useful in local environment, discouraged in production
+logs_volume_host =
+
+# A list of configMapsRefs to envFrom. If more than one configMap is
+# specified, provide a comma separated list: configmap_a,configmap_b
+env_from_configmap_ref =
+
+# A list of secretRefs to envFrom. If more than one secret is
+# specified, provide a comma separated list: secret_a,secret_b
+env_from_secret_ref =
+
 # Git credentials and repository for DAGs mounted via Git (mutually exclusive with volume claim)
 git_repo =
 git_branch =
+git_subpath =
+# Use git_user and git_password for user authentication or git_ssh_key_secret_name and git_ssh_key_secret_key
+# for SSH authentication
 git_user =
 git_password =
 git_subpath =
+git_sync_root = /git
+git_sync_dest = repo
+# Mount point of the volume if git-sync is being used.
+# i.e. /root/airflow/dags
+git_dags_folder_mount_point =
+
+# To get Git-sync SSH authentication set up follow this format
+#
+# airflow-secrets.yaml:
+# ---
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: airflow-secrets
+# data:
+#   # key needs to be gitSshKey
+#   gitSshKey: <base64_encoded_data>
+# ---
+# airflow-configmap.yaml:
+# apiVersion: v1
+# kind: ConfigMap
+# metadata:
+#   name: airflow-configmap
+# data:
+#   known_hosts: |
+#       github.com ssh-rsa <...>
+#   airflow.cfg: |
+#       ...
+#
+# git_ssh_key_secret_name = airflow-secrets
+# git_ssh_known_hosts_configmap_name = airflow-configmap
+git_ssh_key_secret_name =
+git_ssh_known_hosts_configmap_name =
 
 # For cloning DAGs from git repositories into volumes: https://github.com/kubernetes/git-sync
-git_sync_container_repository = gcr.io/google-containers/git-sync-amd64
-git_sync_container_tag = v2.0.5
+git_sync_container_repository = k8s.gcr.io/git-sync
+git_sync_container_tag = v3.1.1
 git_sync_init_container_name = git-sync-clone
 
 # The name of the Kubernetes service account to be associated with airflow workers, if any.
@@ -582,22 +690,67 @@ gcp_service_account_keys =
 # It will raise an exception if called from a process not running in a kubernetes environment.
 in_cluster = True
 
+# When running with in_cluster=False change the default cluster_context or config_file
+# options to Kubernetes client. Leave blank these to use default behaviour like `kubectl` has.
+# cluster_context =
+# config_file =
+
+
+# Affinity configuration as a single line formatted JSON object.
+# See the affinity model for top-level key names (e.g. `nodeAffinity`, etc.):
+#   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#affinity-v1-core
+affinity =
+
+# A list of toleration objects as a single line formatted JSON array
+# See:
+#   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#toleration-v1-core
+tolerations =
+
+# Worker pods security context options
+# See:
+#   https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+
+# Specifies the uid to run the first process of the worker pods containers as
+run_as_user =
+
+# Specifies a gid to associate with all containers in the worker pods
+# if using a git_ssh_key_secret_name use an fs_group
+# that allows for the key to be read, e.g. 65533
+fs_group =
+
 [kubernetes_node_selectors]
 # The Key-value pairs to be given to worker pods.
 # The worker pods will be scheduled to the nodes of the specified key-value pairs.
 # Should be supplied in the format: key = value
+
+[kubernetes_annotations]
+# The Key-value annotations pairs to be given to worker pods.
+# Should be supplied in the format: key = value
+
+[kubernetes_environment_variables]
+# The scheduler sets the following environment variables into your workers. You may define as
+# many environment variables as needed and the kubernetes launcher will set them in the launched workers.
+# Environment variables in this section are defined as follows
+#     <environment_variable_key> = <environment_variable_value>
+#
+# For example if you wanted to set an environment variable with value `prod` and key
+# `ENVIRONMENT` you would follow the following format:
+#     ENVIRONMENT = prod
+#
+# Additionally you may override worker airflow settings with the AIRFLOW__<SECTION>__<KEY>
+# formatting as supported by airflow normally.
 
 [kubernetes_secrets]
 # The scheduler mounts the following secrets into your workers as they are launched by the
 # scheduler. You may define as many secrets as needed and the kubernetes launcher will parse the
 # defined secrets and mount them as secret environment variables in the launched workers.
 # Secrets in this section are defined as follows
-#     <environment_variable_mount> = <kubernetes_secret_object>:<kubernetes_secret_key>
+#     <environment_variable_mount> = <kubernetes_secret_object>=<kubernetes_secret_key>
 #
 # For example if you wanted to mount a kubernetes secret key named `postgres_password` from the
 # kubernetes secret object `airflow-secret` as the environment variable `POSTGRES_PASSWORD` into
 # your workers you would follow the following format:
-#     POSTGRES_PASSWORD = airflow-secret:postgres_credentials
+#     POSTGRES_PASSWORD = airflow-secret=postgres_credentials
 #
 # Additionally you may override worker airflow settings with the AIRFLOW__<SECTION>__<KEY>
 # formatting as supported by airflow normally.

--- a/config/airflow.cfg
+++ b/config/airflow.cfg
@@ -631,7 +631,6 @@ git_subpath =
 # for SSH authentication
 git_user =
 git_password =
-git_subpath =
 git_sync_root = /git
 git_sync_dest = repo
 # Mount point of the volume if git-sync is being used.

--- a/docker-compose-CeleryExecutor.yml
+++ b/docker-compose-CeleryExecutor.yml
@@ -16,7 +16,7 @@ services:
         #     - ./pgdata:/var/lib/postgresql/data/pgdata
 
     webserver:
-        image: puckel/docker-airflow:1.10.2
+        image: puckel/docker-airflow:1.10.3
         restart: always
         depends_on:
             - postgres
@@ -43,7 +43,7 @@ services:
             retries: 3
 
     flower:
-        image: puckel/docker-airflow:1.10.2
+        image: puckel/docker-airflow:1.10.3
         restart: always
         depends_on:
             - redis
@@ -55,7 +55,7 @@ services:
         command: flower
 
     scheduler:
-        image: puckel/docker-airflow:1.10.2
+        image: puckel/docker-airflow:1.10.3
         restart: always
         depends_on:
             - webserver
@@ -74,7 +74,7 @@ services:
         command: scheduler
 
     worker:
-        image: puckel/docker-airflow:1.10.2
+        image: puckel/docker-airflow:1.10.3
         restart: always
         depends_on:
             - scheduler

--- a/docker-compose-LocalExecutor.yml
+++ b/docker-compose-LocalExecutor.yml
@@ -8,7 +8,7 @@ services:
             - POSTGRES_DB=airflow
 
     webserver:
-        image: puckel/docker-airflow:1.10.2
+        image: puckel/docker-airflow:1.10.3
         restart: always
         depends_on:
             - postgres

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -13,12 +13,12 @@ TRY_LOOP="20"
 : "${POSTGRES_DB:="airflow"}"
 
 # Defaults and back-compat
-: "${AIRFLOW__HOME:="/usr/local/airflow"}"
+: "${AIRFLOW_HOME:="/usr/local/airflow"}"
 : "${AIRFLOW__CORE__FERNET_KEY:=${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")}}"
 : "${AIRFLOW__CORE__EXECUTOR:=${EXECUTOR:-Sequential}Executor}"
 
 export \
-  AIRFLOW__HOME \
+  AIRFLOW_HOME \
   AIRFLOW__CELERY__BROKER_URL \
   AIRFLOW__CELERY__RESULT_BACKEND \
   AIRFLOW__CORE__EXECUTOR \

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -13,10 +13,12 @@ TRY_LOOP="20"
 : "${POSTGRES_DB:="airflow"}"
 
 # Defaults and back-compat
+: "${AIRFLOW__HOME:="/usr/local/airflow"}"
 : "${AIRFLOW__CORE__FERNET_KEY:=${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")}}"
 : "${AIRFLOW__CORE__EXECUTOR:=${EXECUTOR:-Sequential}Executor}"
 
 export \
+  AIRFLOW__HOME \
   AIRFLOW__CELERY__BROKER_URL \
   AIRFLOW__CELERY__RESULT_BACKEND \
   AIRFLOW__CORE__EXECUTOR \


### PR DESCRIPTION
Applied the following fixes on top the PR #355: 

1. Minor typo related to `AIRFLOW_HOME` env variable has been fixed in `script/entrypoint.sh`
2. Duplicate 'git_subpath' property in 'config/airflow.cfg' is removed.

Remaining commits have been based on @medmrgh 's PR #355 (Bump airflow 1.10.3)

If it makes sense, you can merge this PR after merging #355, so that only the fixes are applied. However the repo may temporarily be in a broken state.