### PR TITLE
Update Dockerfile and fix the versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,11 +51,12 @@ RUN set -ex \
     && locale-gen \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
     && useradd -ms /bin/bash -d ${AIRFLOW_HOME} airflow \
-    && pip install -U pip setuptools wheel \
-    && pip install pytz \
-    && pip install pyOpenSSL \
-    && pip install ndg-httpsclient \
-    && pip install pyasn1 \
+    && pip install -U pip==19.0.1 setuptools==40.7.0 wheel==0.32.3 \
+    && pip install pytz==2018.9  \
+    && pip install pyOpenSSL==19.0.0 \
+    && pip install ndg-httpsclient==0.5.1 \
+    && pip install pyasn1==0.4.5 \
+    && pip install psycopg2==2.7.7 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
     && pip install 'redis>=2.10.5,<3' \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \


### PR DESCRIPTION
Today doing a build will not work. Because of the psycopg2 to will take version 2.8.2. For this it's better to used fixed versions.