### PR TITLE
Allow to disable config helpers

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -1,70 +1,72 @@
 #!/usr/bin/env bash
 
-TRY_LOOP="20"
-
-: "${REDIS_HOST:="redis"}"
-: "${REDIS_PORT:="6379"}"
-: "${REDIS_PASSWORD:=""}"
-
-: "${POSTGRES_HOST:="postgres"}"
-: "${POSTGRES_PORT:="5432"}"
-: "${POSTGRES_USER:="airflow"}"
-: "${POSTGRES_PASSWORD:="airflow"}"
-: "${POSTGRES_DB:="airflow"}"
-
-# Defaults and back-compat
-: "${AIRFLOW__CORE__FERNET_KEY:=${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")}}"
-: "${AIRFLOW__CORE__EXECUTOR:=${EXECUTOR:-Sequential}Executor}"
-
-export \
-  AIRFLOW__CELERY__BROKER_URL \
-  AIRFLOW__CELERY__RESULT_BACKEND \
-  AIRFLOW__CORE__EXECUTOR \
-  AIRFLOW__CORE__FERNET_KEY \
-  AIRFLOW__CORE__LOAD_EXAMPLES \
-  AIRFLOW__CORE__SQL_ALCHEMY_CONN \
-
-
-# Load DAGs exemples (default: Yes)
-if [[ -z "$AIRFLOW__CORE__LOAD_EXAMPLES" && "${LOAD_EX:=n}" == n ]]
-then
-  AIRFLOW__CORE__LOAD_EXAMPLES=False
-fi
-
 # Install custom python package if requirements.txt is present
 if [ -e "/requirements.txt" ]; then
-    $(which pip) install --user -r /requirements.txt
+  $(which pip) install --user -r /requirements.txt
 fi
 
-if [ -n "$REDIS_PASSWORD" ]; then
-    REDIS_PREFIX=:${REDIS_PASSWORD}@
-else
-    REDIS_PREFIX=
-fi
+if [[ "$NO_CONFIG_HELPER" !=  "true" ]]; then
+  TRY_LOOP="20"
 
-wait_for_port() {
-  local name="$1" host="$2" port="$3"
-  local j=0
-  while ! nc -z "$host" "$port" >/dev/null 2>&1 < /dev/null; do
-    j=$((j+1))
-    if [ $j -ge $TRY_LOOP ]; then
-      echo >&2 "$(date) - $host:$port still not reachable, giving up"
-      exit 1
-    fi
-    echo "$(date) - waiting for $name... $j/$TRY_LOOP"
-    sleep 5
-  done
-}
+  : "${REDIS_HOST:="redis"}"
+  : "${REDIS_PORT:="6379"}"
+  : "${REDIS_PASSWORD:=""}"
 
-if [ "$AIRFLOW__CORE__EXECUTOR" != "SequentialExecutor" ]; then
-  AIRFLOW__CORE__SQL_ALCHEMY_CONN="postgresql+psycopg2://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
-  AIRFLOW__CELERY__RESULT_BACKEND="db+postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
-  wait_for_port "Postgres" "$POSTGRES_HOST" "$POSTGRES_PORT"
-fi
+  : "${POSTGRES_HOST:="postgres"}"
+  : "${POSTGRES_PORT:="5432"}"
+  : "${POSTGRES_USER:="airflow"}"
+  : "${POSTGRES_PASSWORD:="airflow"}"
+  : "${POSTGRES_DB:="airflow"}"
 
-if [ "$AIRFLOW__CORE__EXECUTOR" = "CeleryExecutor" ]; then
-  AIRFLOW__CELERY__BROKER_URL="redis://$REDIS_PREFIX$REDIS_HOST:$REDIS_PORT/1"
-  wait_for_port "Redis" "$REDIS_HOST" "$REDIS_PORT"
+  # Defaults and back-compat
+  : "${AIRFLOW__CORE__FERNET_KEY:=${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")}}"
+  : "${AIRFLOW__CORE__EXECUTOR:=${EXECUTOR:-Sequential}Executor}"
+
+  export \
+    AIRFLOW__CELERY__BROKER_URL \
+    AIRFLOW__CELERY__RESULT_BACKEND \
+    AIRFLOW__CORE__EXECUTOR \
+    AIRFLOW__CORE__FERNET_KEY \
+    AIRFLOW__CORE__LOAD_EXAMPLES \
+    AIRFLOW__CORE__SQL_ALCHEMY_CONN \
+
+
+  # Load DAGs exemples (default: Yes)
+  if [[ -z "$AIRFLOW__CORE__LOAD_EXAMPLES" && "${LOAD_EX:=n}" == n ]]
+  then
+    AIRFLOW__CORE__LOAD_EXAMPLES=False
+  fi
+
+  if [ -n "$REDIS_PASSWORD" ]; then
+      REDIS_PREFIX=:${REDIS_PASSWORD}@
+  else
+      REDIS_PREFIX=
+  fi
+
+  wait_for_port() {
+    local name="$1" host="$2" port="$3"
+    local j=0
+    while ! nc -z "$host" "$port" >/dev/null 2>&1 < /dev/null; do
+      j=$((j+1))
+      if [ $j -ge $TRY_LOOP ]; then
+        echo >&2 "$(date) - $host:$port still not reachable, giving up"
+        exit 1
+      fi
+      echo "$(date) - waiting for $name... $j/$TRY_LOOP"
+      sleep 5
+    done
+  }
+
+  if [ "$AIRFLOW__CORE__EXECUTOR" != "SequentialExecutor" ]; then
+    AIRFLOW__CORE__SQL_ALCHEMY_CONN="postgresql+psycopg2://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
+    AIRFLOW__CELERY__RESULT_BACKEND="db+postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
+    wait_for_port "Postgres" "$POSTGRES_HOST" "$POSTGRES_PORT"
+  fi
+
+  if [ "$AIRFLOW__CORE__EXECUTOR" = "CeleryExecutor" ]; then
+    AIRFLOW__CELERY__BROKER_URL="redis://$REDIS_PREFIX$REDIS_HOST:$REDIS_PORT/1"
+    wait_for_port "Redis" "$REDIS_HOST" "$REDIS_PORT"
+  fi
 fi
 
 case "$1" in


### PR DESCRIPTION
`NO_CONFIG_HELPER=true` disables every configuration of `AIRFLOW__*` variables (and also implicitly the `wait_for_port` function)

The optional requirements installation has been moved to the top to be out of the configuration helper block.