### PR TITLE
Python baseimage update to version 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,10 @@ jobs:
           name: Build docker image
           command: |
             docker build -t puckel/docker-airflow .
+      - run:
+          name: Test Python version
+          command: |
+            docker run puckel/docker-airflow python -V | grep '3.7'
       - run: 
           name: Test docker image
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # BUILD: docker build --rm -t puckel/docker-airflow .
 # SOURCE: https://github.com/puckel/docker-airflow
 
-FROM python:3.6-slim
+FROM python:3.7-slim
 LABEL maintainer="Puckel_"
 
 # Never prompts the user for choices on installation/configuration of packages

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains **Dockerfile** of [apache-airflow](https://github.com/a
 
 ## Informations
 
-* Based on Python (3.6-slim) official Image [python:3.6-slim](https://hub.docker.com/_/python/) and uses the official [Postgres](https://hub.docker.com/_/postgres/) as backend and [Redis](https://hub.docker.com/_/redis/) as queue
+* Based on Python (3.7-slim) official Image [python:3.7-slim](https://hub.docker.com/_/python/) and uses the official [Postgres](https://hub.docker.com/_/postgres/) as backend and [Redis](https://hub.docker.com/_/redis/) as queue
 * Install [Docker](https://www.docker.com/)
 * Install [Docker Compose](https://docs.docker.com/compose/install/)
 * Following the Airflow release from [Python Package Index](https://pypi.python.org/pypi/apache-airflow)


### PR DESCRIPTION
This PR provides:
- Dockerfile update so it points to Python 3.7 baseimage.
- Corresponding Python version test in CI script.
- Minor update in README.