### PR TITLE
Fix werkzeug dependency that breaks image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN set -ex \
     && pip install pyasn1 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
     && pip install 'redis==3.2' \
+    && pip install 'werkzeug>=0.15.0' \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get autoremove -yqq --purge \


### PR DESCRIPTION
* This fixes the problem described in https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-4900

```
ERROR: Failure: ImportError (No module named 'werkzeug.wrappers.json'; 
'werkzeug.wrappers' is not a package)
```

* Based on the corresponding fix in Airflow
   * https://github.com/apache/airflow/pull/5535

