### PR TITLE
support RBAC + ldap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN set -ex \
     && buildDeps=' \
         freetds-dev \
         libkrb5-dev \
+        libldap2-dev \
         libsasl2-dev \
         libssl-dev \
         libffi-dev \
@@ -54,6 +55,7 @@ RUN set -ex \
     && pip install -U pip setuptools wheel \
     && pip install pytz \
     && pip install pyOpenSSL \
+    && pip install python-ldap \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \


### PR DESCRIPTION
When using ldap in webserver_config.py, the ldap module is missing and cannot be added since libldap2-dev is not installed.

This PR adds libldap2-dev during image build and installs python-ldap.