### PR TITLE
Add optional importing of Airflow variables in entrypoint.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ In order to incorporate plugins into your docker container
 - Mount this file as a volume `-v $(pwd)/requirements.txt:/requirements.txt` (or add it as a volume in docker-compose file)
 - The entrypoint.sh script execute the pip install command (with --user option)
 
+## Import Airflow variables
+
+- Create a file "variables.json" containing your desired Airflow variables in the format of `{"key": "value"}` (or export from Airflow Web GUI)
+- Mount this file as a volume `-v $(pwd)/variables.json:/variables.json` (or add it as a volume in docker-compose file)
+- The entrypoint.sh script will execute `airflow variables --import /variables.json` when Airflow is up and running
+
 ## UI Links
 
 - Airflow: [localhost:8080](http://localhost:8080/)

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -76,6 +76,9 @@ case "$1" in
       # With the "Local" executor it should all run in one container.
       airflow scheduler &
     fi
+    if [ -e "/variables.json" ]; then
+      airflow variables --import /variables.json
+    fi
     exec airflow webserver
     ;;
   worker|scheduler)


### PR DESCRIPTION
Hello,

I stumbled across this repo recently and I want to thank you for setting it up. I need to import Airflow variables from my prod env. and I couldn't find a way to do this reading the docs or source code so i added it, its a small change but adds a lot of value for me (and hopefully others). 

If there is a better way of doing this or you have any comments regarding my approach please share.