### PR TITLE
Downgrade kombu version to allow celery-cli to work within the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN set -ex \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
+    && pip install 'kombu==4.6.3' --force-reinstall \
     && pip install 'redis==3.2' \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \
     && apt-get purge --auto-remove -yqq $buildDeps \


### PR DESCRIPTION
With the default :

```
celery==4.3.0
kombu==4.6.5
```

The celery cli command `celery inspect active` for example reply with an error `Error: No nodes replied within time constraint.`.

This PR downgrade kombu to version 4.6.3 based on this https://github.com/celery/kombu/issues/1087  to work with `celery==4.3.0`