### PR TITLE
Include serve_logs command

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -87,6 +87,10 @@ case "$1" in
     sleep 10
     exec airflow "$@"
     ;;
+  serve_logs)
+    sleep 10
+    exec airflow "$@"
+    ;;
   version)
     exec airflow "$@"
     ;;


### PR DESCRIPTION
This command exposes logs in `localhost:8793/log/{dag_id}/{task_id}/{execution_date}/{try_number}.log`