### PR TITLE
Set unique celery worker names to allow for multiple workers.

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -78,8 +78,14 @@ case "$1" in
     fi
     exec airflow webserver
     ;;
-  worker|scheduler)
-    # Give the webserver time to run initdb.
+  worker)
+    # To give the webserver time to run initdb.
+    sleep 10
+    # Each celery worker needs a unique name otherwise only one will work. Adds microseconds as prefix.
+    exec airflow "$@" -cn "worker-$(($(date +%s%N)/1000000))"
+    ;;
+  scheduler)
+    # To give the webserver time to run initdb.
     sleep 10
     exec airflow "$@"
     ;;


### PR DESCRIPTION
As stated in https://airflow.apache.org/docs/stable/cli.html#worker celery worker must have a unique hostname if more than one works on the same host. On contexts such as [AWS ECS ](https://aws.amazon.com/ecs/) it would be considerably easier to run multiple celery workers by default as all containers will get the same hostname.