### PR TITLE
Reads in webserver secret_key at runtime

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -11,6 +11,7 @@ TRY_LOOP="20"
 : "${AIRFLOW_HOME:="/usr/local/airflow"}"
 : "${AIRFLOW__CORE__FERNET_KEY:=${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")}}"
 : "${AIRFLOW__CORE__EXECUTOR:=${EXECUTOR:-Sequential}Executor}"
+: "${AIRFLOW__WEBSERVER__SECRET_KEY:=$(python -c "import secrets; WEBSERVER_SECRET_KEY = secrets.token_urlsafe(32); print(WEBSERVER_SECRET_KEY)")}"
 
 # Load DAGs examples (default: Yes)
 if [[ -z "$AIRFLOW__CORE__LOAD_EXAMPLES" && "${LOAD_EX:=n}" == n ]]; then
@@ -22,6 +23,7 @@ export \
   AIRFLOW__CORE__EXECUTOR \
   AIRFLOW__CORE__FERNET_KEY \
   AIRFLOW__CORE__LOAD_EXAMPLES \
+  AIRFLOW__WEBSERVER__SECRET_KEY \
 
 # Install custom python package if requirements.txt is present
 if [ -e "/requirements.txt" ]; then


### PR DESCRIPTION
# Description of PR

Generate the `webserver` `secret_key` in the `entrypoint.sh`

This will be helpful if people run in a multi tenant mode with auth.

Previously if you had multiple instances running with auth and didn't change the secret (i.e. you forgot to or didn't realize you needed to) you would be able to jump from cluster to cluster because the session would be valid once authorized for the first time.



## Previous Behavior 
in section `webserver` `secret_key` defaults to `temporary_key`

## Current Behavior

secret_key is uniquely generated at run time

<img width="1383" alt="Screen Shot 2020-03-06 at 1 04 38 PM" src="https://user-images.githubusercontent.com/6012231/76122514-0cfa5480-5fab-11ea-9c67-a7458a7aab98.png">
