### PR TITLE
Add support for restart on watched files.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ LABEL maintainer="Puckel_"
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
+# Use entr(1) (http://eradman.com/entrproject/) to restart if these files change
+# (e.g. requirements.txt being updated by a sidecar sync process)
+ENV WATCHED_FILES=""
+
 # Airflow
 ARG AIRFLOW_VERSION=1.10.9
 ARG AIRFLOW_USER_HOME=/usr/local/airflow
@@ -50,6 +54,7 @@ RUN set -ex \
         rsync \
         netcat \
         locales \
+        entr \
     && sed -i 's/^# en_US.UTF-8 UTF-8$/en_US.UTF-8 UTF-8/g' /etc/locale.gen \
     && locale-gen \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
@@ -74,6 +79,7 @@ RUN set -ex \
         /usr/share/doc-base
 
 COPY script/entrypoint.sh /entrypoint.sh
+COPY script/run.sh /run.sh
 COPY config/airflow.cfg ${AIRFLOW_USER_HOME}/airflow.cfg
 
 RUN chown -R airflow: ${AIRFLOW_USER_HOME}

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -1,135 +1,38 @@
-#!/usr/bin/env bash
-
-# User-provided configuration must always be respected.
-#
-# Therefore, this script must only derives Airflow AIRFLOW__ variables from other variables
-# when the user did not provide their own configuration.
-
-TRY_LOOP="20"
-
-# Global defaults and back-compat
-: "${AIRFLOW_HOME:="/usr/local/airflow"}"
-: "${AIRFLOW__CORE__FERNET_KEY:=${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")}}"
-: "${AIRFLOW__CORE__EXECUTOR:=${EXECUTOR:-Sequential}Executor}"
-
-# Load DAGs examples (default: Yes)
-if [[ -z "$AIRFLOW__CORE__LOAD_EXAMPLES" && "${LOAD_EX:=n}" == n ]]; then
-  AIRFLOW__CORE__LOAD_EXAMPLES=False
-fi
-
-export \
-  AIRFLOW_HOME \
-  AIRFLOW__CORE__EXECUTOR \
-  AIRFLOW__CORE__FERNET_KEY \
-  AIRFLOW__CORE__LOAD_EXAMPLES \
-
-# Install custom python package if requirements.txt is present
-if [ -e "/requirements.txt" ]; then
-    $(command -v pip) install --user -r /requirements.txt
-fi
-
-wait_for_port() {
-  local name="$1" host="$2" port="$3"
-  local j=0
-  while ! nc -z "$host" "$port" >/dev/null 2>&1 < /dev/null; do
-    j=$((j+1))
-    if [ $j -ge $TRY_LOOP ]; then
-      echo >&2 "$(date) - $host:$port still not reachable, giving up"
-      exit 1
-    fi
-    echo "$(date) - waiting for $name... $j/$TRY_LOOP"
-    sleep 5
-  done
-}
-
-# Other executors than SequentialExecutor drive the need for an SQL database, here PostgreSQL is used
-if [ "$AIRFLOW__CORE__EXECUTOR" != "SequentialExecutor" ]; then
-  # Check if the user has provided explicit Airflow configuration concerning the database
-  if [ -z "$AIRFLOW__CORE__SQL_ALCHEMY_CONN" ]; then
-    # Default values corresponding to the default compose files
-    : "${POSTGRES_HOST:="postgres"}"
-    : "${POSTGRES_PORT:="5432"}"
-    : "${POSTGRES_USER:="airflow"}"
-    : "${POSTGRES_PASSWORD:="airflow"}"
-    : "${POSTGRES_DB:="airflow"}"
-    : "${POSTGRES_EXTRAS:-""}"
-
-    AIRFLOW__CORE__SQL_ALCHEMY_CONN="postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}${POSTGRES_EXTRAS}"
-    export AIRFLOW__CORE__SQL_ALCHEMY_CONN
-
-    # Check if the user has provided explicit Airflow configuration for the broker's connection to the database
-    if [ "$AIRFLOW__CORE__EXECUTOR" = "CeleryExecutor" ]; then
-      AIRFLOW__CELERY__RESULT_BACKEND="db+postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}${POSTGRES_EXTRAS}"
-      export AIRFLOW__CELERY__RESULT_BACKEND
-    fi
-  else
-    if [[ "$AIRFLOW__CORE__EXECUTOR" == "CeleryExecutor" && -z "$AIRFLOW__CELERY__RESULT_BACKEND" ]]; then
-      >&2 printf '%s\n' "FATAL: if you set AIRFLOW__CORE__SQL_ALCHEMY_CONN manually with CeleryExecutor you must also set AIRFLOW__CELERY__RESULT_BACKEND"
-      exit 1
-    fi
-
-    # Derive useful variables from the AIRFLOW__ variables provided explicitly by the user
-    POSTGRES_ENDPOINT=$(echo -n "$AIRFLOW__CORE__SQL_ALCHEMY_CONN" | cut -d '/' -f3 | sed -e 's,.*@,,')
-    POSTGRES_HOST=$(echo -n "$POSTGRES_ENDPOINT" | cut -d ':' -f1)
-    POSTGRES_PORT=$(echo -n "$POSTGRES_ENDPOINT" | cut -d ':' -f2)
-  fi
-
-  wait_for_port "Postgres" "$POSTGRES_HOST" "$POSTGRES_PORT"
-fi
-
-# CeleryExecutor drives the need for a Celery broker, here Redis is used
-if [ "$AIRFLOW__CORE__EXECUTOR" = "CeleryExecutor" ]; then
-  # Check if the user has provided explicit Airflow configuration concerning the broker
-  if [ -z "$AIRFLOW__CELERY__BROKER_URL" ]; then
-    # Default values corresponding to the default compose files
-    : "${REDIS_PROTO:="redis://"}"
-    : "${REDIS_HOST:="redis"}"
-    : "${REDIS_PORT:="6379"}"
-    : "${REDIS_PASSWORD:=""}"
-    : "${REDIS_DBNUM:="1"}"
-
-    # When Redis is secured by basic auth, it does not handle the username part of basic auth, only a token
-    if [ -n "$REDIS_PASSWORD" ]; then
-      REDIS_PREFIX=":${REDIS_PASSWORD}@"
-    else
-      REDIS_PREFIX=
-    fi
-
-    AIRFLOW__CELERY__BROKER_URL="${REDIS_PROTO}${REDIS_PREFIX}${REDIS_HOST}:${REDIS_PORT}/${REDIS_DBNUM}"
-    export AIRFLOW__CELERY__BROKER_URL
-  else
-    # Derive useful variables from the AIRFLOW__ variables provided explicitly by the user
-    REDIS_ENDPOINT=$(echo -n "$AIRFLOW__CELERY__BROKER_URL" | cut -d '/' -f3 | sed -e 's,.*@,,')
-    REDIS_HOST=$(echo -n "$POSTGRES_ENDPOINT" | cut -d ':' -f1)
-    REDIS_PORT=$(echo -n "$POSTGRES_ENDPOINT" | cut -d ':' -f2)
-  fi
-
-  wait_for_port "Redis" "$REDIS_HOST" "$REDIS_PORT"
-fi
+#!/bin/bash -e
 
 case "$1" in
-  webserver)
-    airflow initdb
-    if [ "$AIRFLOW__CORE__EXECUTOR" = "LocalExecutor" ] || [ "$AIRFLOW__CORE__EXECUTOR" = "SequentialExecutor" ]; then
-      # With the "Local" and "Sequential" executors it should all run in one container.
-      airflow scheduler &
-    fi
-    exec airflow webserver
-    ;;
-  worker|scheduler)
-    # Give the webserver time to run initdb.
-    sleep 10
-    exec airflow "$@"
-    ;;
-  flower)
-    sleep 10
-    exec airflow "$@"
-    ;;
-  version)
-    exec airflow "$@"
+  webserver|flower|version|worker|scheduler)
+    CMD="$@"
     ;;
   *)
-    # The command is something like bash, not an airflow subcommand. Just run it in the right environment.
-    exec "$@"
+    # The command is something like bash, not an airflow subcommand. Turn it into
+    # a file to avoid shell quoting nightmares.
+    CUSTOM=$(mktemp)
+    echo "#!/bin/bash -ex" > ${CUSTOM}
+    chmod 755 ${CUSTOM}
+    echo "$@" >> ${CUSTOM}
+    CMD="${CUSTOM}"
+    echo "*** Custom command:"
+    echo
+    cat ${CUSTOM}
+    echo
+    echo "*** End custom command"
     ;;
 esac
+
+echo "*** CMD: '${CMD}'"
+
+if [ "${WATCH_FILES}" ]; then
+  WATCHED_FILES=""
+  for file in ${WATCH_FILES}; do
+    if ! [ -e "${file}" ]; then
+      echo "*** WARNING: ${file} does not appear to exist; attempting to create it"
+      touch "${file}"
+    fi
+  done
+  echo "*** Watching: ${WATCH_FILES}"
+  ls ${WATCH_FILES} | entr -r /run.sh ${CMD}
+fi
+
+echo "*** Watching no files"
+exec /run.sh ${CMD}

--- a/script/run.sh
+++ b/script/run.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+# User-provided configuration must always be respected.
+#
+# Therefore, this script must only derives Airflow AIRFLOW__ variables from other variables
+# when the user did not provide their own configuration.
+
+TRY_LOOP="20"
+
+# Global defaults and back-compat
+: "${AIRFLOW_HOME:="/usr/local/airflow"}"
+: "${AIRFLOW__CORE__FERNET_KEY:=${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")}}"
+: "${AIRFLOW__CORE__EXECUTOR:=${EXECUTOR:-Sequential}Executor}"
+
+# Load DAGs examples (default: Yes)
+if [[ -z "$AIRFLOW__CORE__LOAD_EXAMPLES" && "${LOAD_EX:=n}" == n ]]; then
+  AIRFLOW__CORE__LOAD_EXAMPLES=False
+fi
+
+export \
+  AIRFLOW_HOME \
+  AIRFLOW__CORE__EXECUTOR \
+  AIRFLOW__CORE__FERNET_KEY \
+  AIRFLOW__CORE__LOAD_EXAMPLES \
+
+# Install custom python package if requirements.txt is present
+if [ -e "/requirements.txt" ]; then
+    $(command -v pip) install --user -r /requirements.txt
+fi
+
+wait_for_port() {
+  local name="$1" host="$2" port="$3"
+  local j=0
+  while ! nc -z "$host" "$port" >/dev/null 2>&1 < /dev/null; do
+    j=$((j+1))
+    if [ $j -ge $TRY_LOOP ]; then
+      echo >&2 "$(date) - $host:$port still not reachable, giving up"
+      exit 1
+    fi
+    echo "$(date) - waiting for $name... $j/$TRY_LOOP"
+    sleep 5
+  done
+}
+
+# Other executors than SequentialExecutor drive the need for an SQL database, here PostgreSQL is used
+if [ "$AIRFLOW__CORE__EXECUTOR" != "SequentialExecutor" ]; then
+  # Check if the user has provided explicit Airflow configuration concerning the database
+  if [ -z "$AIRFLOW__CORE__SQL_ALCHEMY_CONN" ]; then
+    # Default values corresponding to the default compose files
+    : "${POSTGRES_HOST:="postgres"}"
+    : "${POSTGRES_PORT:="5432"}"
+    : "${POSTGRES_USER:="airflow"}"
+    : "${POSTGRES_PASSWORD:="airflow"}"
+    : "${POSTGRES_DB:="airflow"}"
+    : "${POSTGRES_EXTRAS:-""}"
+
+    AIRFLOW__CORE__SQL_ALCHEMY_CONN="postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}${POSTGRES_EXTRAS}"
+    export AIRFLOW__CORE__SQL_ALCHEMY_CONN
+
+    # Check if the user has provided explicit Airflow configuration for the broker's connection to the database
+    if [ "$AIRFLOW__CORE__EXECUTOR" = "CeleryExecutor" ]; then
+      AIRFLOW__CELERY__RESULT_BACKEND="db+postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}${POSTGRES_EXTRAS}"
+      export AIRFLOW__CELERY__RESULT_BACKEND
+    fi
+  else
+    if [[ "$AIRFLOW__CORE__EXECUTOR" == "CeleryExecutor" && -z "$AIRFLOW__CELERY__RESULT_BACKEND" ]]; then
+      >&2 printf '%s\n' "FATAL: if you set AIRFLOW__CORE__SQL_ALCHEMY_CONN manually with CeleryExecutor you must also set AIRFLOW__CELERY__RESULT_BACKEND"
+      exit 1
+    fi
+
+    # Derive useful variables from the AIRFLOW__ variables provided explicitly by the user
+    POSTGRES_ENDPOINT=$(echo -n "$AIRFLOW__CORE__SQL_ALCHEMY_CONN" | cut -d '/' -f3 | sed -e 's,.*@,,')
+    POSTGRES_HOST=$(echo -n "$POSTGRES_ENDPOINT" | cut -d ':' -f1)
+    POSTGRES_PORT=$(echo -n "$POSTGRES_ENDPOINT" | cut -d ':' -f2)
+  fi
+
+  wait_for_port "Postgres" "$POSTGRES_HOST" "$POSTGRES_PORT"
+fi
+
+# CeleryExecutor drives the need for a Celery broker, here Redis is used
+if [ "$AIRFLOW__CORE__EXECUTOR" = "CeleryExecutor" ]; then
+  # Check if the user has provided explicit Airflow configuration concerning the broker
+  if [ -z "$AIRFLOW__CELERY__BROKER_URL" ]; then
+    # Default values corresponding to the default compose files
+    : "${REDIS_PROTO:="redis://"}"
+    : "${REDIS_HOST:="redis"}"
+    : "${REDIS_PORT:="6379"}"
+    : "${REDIS_PASSWORD:=""}"
+    : "${REDIS_DBNUM:="1"}"
+
+    # When Redis is secured by basic auth, it does not handle the username part of basic auth, only a token
+    if [ -n "$REDIS_PASSWORD" ]; then
+      REDIS_PREFIX=":${REDIS_PASSWORD}@"
+    else
+      REDIS_PREFIX=
+    fi
+
+    AIRFLOW__CELERY__BROKER_URL="${REDIS_PROTO}${REDIS_PREFIX}${REDIS_HOST}:${REDIS_PORT}/${REDIS_DBNUM}"
+    export AIRFLOW__CELERY__BROKER_URL
+  else
+    # Derive useful variables from the AIRFLOW__ variables provided explicitly by the user
+    REDIS_ENDPOINT=$(echo -n "$AIRFLOW__CELERY__BROKER_URL" | cut -d '/' -f3 | sed -e 's,.*@,,')
+    REDIS_HOST=$(echo -n "$POSTGRES_ENDPOINT" | cut -d ':' -f1)
+    REDIS_PORT=$(echo -n "$POSTGRES_ENDPOINT" | cut -d ':' -f2)
+  fi
+
+  wait_for_port "Redis" "$REDIS_HOST" "$REDIS_PORT"
+fi
+
+case "$1" in
+  webserver)
+    airflow initdb
+    if [ "$AIRFLOW__CORE__EXECUTOR" = "LocalExecutor" ] || [ "$AIRFLOW__CORE__EXECUTOR" = "SequentialExecutor" ]; then
+      # With the "Local" and "Sequential" executors it should all run in one container.
+      airflow scheduler &
+    fi
+    exec airflow webserver
+    ;;
+  worker|scheduler)
+    # Give the webserver time to run initdb.
+    sleep 10
+    exec airflow "$@"
+    ;;
+  flower)
+    sleep 10
+    exec airflow "$@"
+    ;;
+  version)
+    exec airflow "$@"
+    ;;
+  *)
+    # The command is something like bash, not an airflow subcommand. Just run it in the right environment.
+    exec "$@"
+    ;;
+esac


### PR DESCRIPTION
If the env variable `WATCH_FILES` is set, use the
[entr(1)](http://eradman.com/entrproject/) tool to wrap the entrypoint
script to automatically restart the airflow process if a change is
detected in any of the watched files.

The use case here is: a sidecar container syncs the dags directory from
an external source, and that sync updates
/usr/local/airflow/dags/requirements.txt: in this case we would want to
restart the airflow process after re-processing the requirements.