### PR TITLE
user Airflow in group root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ COPY script/entrypoint.sh /entrypoint.sh
 COPY config/airflow.cfg ${AIRFLOW_USER_HOME}/airflow.cfg
 
 RUN chown -R airflow: ${AIRFLOW_USER_HOME}
+RUN chgrp -R 0 /usr/local/airflow && chmod -R g+rwX /usr/local/airflow
 
 EXPOSE 8080 5555 8793
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ COPY script/entrypoint.sh /entrypoint.sh
 COPY config/airflow.cfg ${AIRFLOW_USER_HOME}/airflow.cfg
 
 RUN chown -R airflow: ${AIRFLOW_USER_HOME}
-RUN chgrp -R 0 /usr/local/airflow && chmod -R g+rwX /usr/local/airflow
+RUN chgrp -R 0 ${AIRFLOW_USER_HOME} && chmod -R g+rwX ${AIRFLOW_USER_HOME}
 
 EXPOSE 8080 5555 8793
 


### PR DESCRIPTION
This is a PR for issue #509   
Added a line to make airflow user a part of the root group.
```
RUN chgrp -R 0 /usr/local/airflow && chmod -R g+rwX /usr/local/airflow
```
This fixes permission issues for Openshift deployments. 