### PR TITLE
Updating Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN set -ex \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
     && useradd -ms /bin/bash -d ${AIRFLOW_USER_HOME} airflow \
     && pip install -U pip setuptools wheel \
+    && pip install SQLAlchemy==1.3.15 \
     && pip install pytz \
     && pip install pyOpenSSL \
     && pip install ndg-httpsclient \


### PR DESCRIPTION
Starting Airflow webserver fails with sqlalchemy.exc.NoInspectionAvailable: No inspection system is available. This is due to SCLAlchemy version being incompatible. 

https://github.com/apache/airflow/issues/8211