### PR TITLE
Added libldap2-dev & python-dev to install python-ldap module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ ENV LC_MESSAGES en_US.UTF-8
 
 RUN set -ex \
     && buildDeps=' \
+        libldap2-dev \
+        python-dev \
         freetds-dev \
         libkrb5-dev \
         libsasl2-dev \


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30810652/87250234-28e79880-c46c-11ea-8fc3-04bb054c5eff.png)

When enabling ldap configuration it fails.
I did some research and tests, and it seems those libraries are missing in order to install python-ldap python module.
With Python-ldap ldap works.