### PR TITLE
Move from python:3.7-slim-buster to python:3.8-slim-buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # BUILD: docker build --rm -t puckel/docker-airflow .
 # SOURCE: https://github.com/puckel/docker-airflow
 
-FROM python:3.7-slim-buster
+FROM python:3.8-slim-buster
 LABEL maintainer="Puckel_"
 
 # Never prompt the user for choices on installation/configuration of packages

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains **Dockerfile** of [apache-airflow](https://github.com/a
 
 ## Informations
 
-* Based on Python (3.7-slim-buster) official Image [python:3.7-slim-buster](https://hub.docker.com/_/python/) and uses the official [Postgres](https://hub.docker.com/_/postgres/) as backend and [Redis](https://hub.docker.com/_/redis/) as queue
+* Based on Python (3.8-slim-buster) official Image [python:3.8-slim-buster](https://hub.docker.com/_/python/) and uses the official [Postgres](https://hub.docker.com/_/postgres/) as backend and [Redis](https://hub.docker.com/_/redis/) as queue
 * Install [Docker](https://www.docker.com/)
 * Install [Docker Compose](https://docs.docker.com/compose/install/)
 * Following the Airflow release from [Python Package Index](https://pypi.python.org/pypi/apache-airflow)


### PR DESCRIPTION
I was able to build the image locally with no issues.  I am unsure how to test the image further post-build but I have run the commands in the github action definition for the locally built image and while the `python -V` command returns the correct version (Python 3.8.12) the `version` command returns a stack trace.

```
 ❯ docker run 57f16f6a9295 version                                  
Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 26, in <module>
    from airflow.bin.cli import CLIFactory
  File "/usr/local/lib/python3.8/site-packages/airflow/bin/cli.py", line 70, in <module>
    from airflow.www.app import (cached_app, create_app)
  File "/usr/local/lib/python3.8/site-packages/airflow/www/app.py", line 37, in <module>
    from airflow.www.blueprints import routes
  File "/usr/local/lib/python3.8/site-packages/airflow/www/blueprints.py", line 25, in <module>
    from airflow.www import utils as wwwutils
  File "/usr/local/lib/python3.8/site-packages/airflow/www/utils.py", line 35, in <module>
    from wtforms.compat import text_type
ModuleNotFoundError: No module named 'wtforms.compat'
```
